### PR TITLE
Potential fix for code scanning alert no. 5: Code injection

### DIFF
--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -30,9 +30,11 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR and Branch References
+        env:
+          HEAD_BRANCH_REF: ${{ github.event.workflow_run.head_branch || github.ref_name }}
         run: |
           git fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*' || true
-          git fetch origin ${{ github.event.workflow_run.head_branch || github.ref_name }} || true
+          git fetch origin "$HEAD_BRANCH_REF" || true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Garrettc123/nwu-protocol/security/code-scanning/5](https://github.com/Garrettc123/nwu-protocol/security/code-scanning/5)

To fix this, stop interpolating the GitHub expression directly into the shell line. Instead, assign the expression to an environment variable in the step, and then reference that variable using normal shell syntax (`$VAR`). This avoids the GitHub expression language injecting directly into the shell command line and ensures the shell receives the value as a single argument (subject only to normal quoting you control).

Concretely, in `.github/workflows/codex-autofix.yml`, in the “Fetch PR and Branch References” step, add an `env:` section setting e.g. `HEAD_BRANCH_REF: ${{ github.event.workflow_run.head_branch || github.ref_name }}`. Then modify the `git fetch` command to use `"$HEAD_BRANCH_REF"` instead of the `${{ ... }}` expression. This keeps existing behavior (still fetching the same ref) while preventing code injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Harden the codex-autofix workflow against code injection by avoiding direct interpolation of GitHub expressions into the git fetch shell command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow configuration to enhance reliability of automated branch handling in the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->