### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
-  permissions:
+permissions:
   contents: read
   pull-requests: write
   checks: write


### PR DESCRIPTION
Potential fix for [https://github.com/Garrettc123/nwu-protocol/security/code-scanning/40](https://github.com/Garrettc123/nwu-protocol/security/code-scanning/40)

In general, to fix this issue you should define an explicit `permissions` block either at the workflow root (to apply to all jobs) or per job, granting only the minimal permissions required. For this workflow, the intended minimal permissions are already visible: `contents: read`, `pull-requests: write`, and `checks: write`. These just need to be declared correctly at the root level, not under `on:`.

The best fix without changing behavior is:

- Remove (or rather, replace) the incorrectly indented `permissions` section currently under `on:` at lines 10–14.
- Add a correctly indented, root-level `permissions` block between the `on:` section and the `jobs:` section:
  - It should be at the same indentation level as `name`, `on`, and `jobs`.
  - Its children (`contents: read`, `pull-requests: write`, `checks: write`) should be indented two spaces under `permissions:`.
- This block will then apply to all jobs that do not have their own `permissions` block, including `test-backend`, satisfying CodeQL’s requirement and enforcing least privilege.

No imports, methods, or other definitions are needed; this is a pure YAML structure/indentation correction in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Move the GitHub Actions `permissions` block from under the `on:` section to the workflow root so it applies correctly to all jobs and enforces least-privilege access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected workflow configuration structure to ensure proper permission handling in continuous integration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->