### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -229,6 +229,8 @@ jobs:
     name: Dependency Health Check
     runs-on: ubuntu-latest
     if: hashFiles('backend/**') != '' || hashFiles('frontend/**') != '' || hashFiles('contracts/**') != ''
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
Potential fix for [https://github.com/Garrettc123/nwu-protocol/security/code-scanning/38](https://github.com/Garrettc123/nwu-protocol/security/code-scanning/38)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions for the affected job. Since `dependency-check` only needs to read the repository contents (for `actions/checkout` and reading `package.json` files) and does not write anything back to GitHub, the least-privilege configuration is `contents: read`.

The best fix without changing existing functionality is to add a `permissions` block under the `dependency-check` job definition. Concretely, in `.github/workflows/quality-checks.yml`, beneath the existing `runs-on: ubuntu-latest` (line 230) for the `dependency-check` job, insert:

```yaml
    permissions:
      contents: read
```

This mirrors the CodeQL recommendation and documents the job’s needs while preventing it from inheriting broader default permissions. No additional imports, steps, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Set explicit read-only contents permissions for the dependency-check job in the quality-checks GitHub Actions workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to apply proper permission scoping to automated dependency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->