### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -9,6 +9,9 @@ on:
       - develop
       - 'copilot/**'  # Include Copilot PR branches
 
+permissions:
+  contents: read
+
 jobs:
   check-repository:
     name: Repository Structure Check


### PR DESCRIPTION
Potential fix for [https://github.com/Garrettc123/nwu-protocol/security/code-scanning/37](https://github.com/Garrettc123/nwu-protocol/security/code-scanning/37)

To fix this, we should add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to read-only access, since these jobs only need to read repository contents. The cleanest approach is to define `permissions` at the workflow root so it automatically applies to all jobs (`check-repository`, `backend-quality`, `contracts-quality`, `agents-quality`, `security-scan`, `complexity-check`, `dependency-check`, `report-summary`, etc.) that do not override it. Based on the shown steps—checking out code, installing dependencies, running linters/tests/complexity tools, and uploading artifacts/coverage—no job needs write access to the repository, issues, or pull requests.

Concretely, in `.github/workflows/quality-checks.yml`, we should insert a top-level `permissions:` block immediately after the `on:` block (after line 10, before `jobs:` on line 12). The minimal recommended set is `contents: read`, which aligns with the CodeQL suggestion. None of the shown actions (including `codecov/codecov-action@v3`, `aquasecurity/trivy-action@master`, or `actions/upload-artifact` implied later) require elevated GitHub API permissions beyond reading repository contents; they primarily use external APIs or upload artifacts via the GitHub Actions runtime. This change preserves existing behavior while explicitly constraining the token.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add a top-level permissions block to the quality-checks workflow to limit GITHUB_TOKEN to contents: read.